### PR TITLE
Improve training plan generation

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,9 +83,13 @@
                         <label for="days">Días disponibles para entrenar</label>
                         <select id="days" name="days" required>
                             <option value="">Selecciona...</option>
+                            <option value="1">1 día</option>
+                            <option value="2">2 días</option>
                             <option value="3">3 días</option>
                             <option value="4">4 días</option>
                             <option value="5">5 días</option>
+                            <option value="6">6 días</option>
+                            <option value="7">7 días</option>
                         </select>
                     </div>
 

--- a/script.js
+++ b/script.js
@@ -44,6 +44,15 @@ class TrainingGenerator {
         });
     }
 
+    // Baraja un arreglo aleatoriamente
+    shuffleArray(array) {
+        for (let i = array.length - 1; i > 0; i--) {
+            const j = Math.floor(Math.random() * (i + 1));
+            [array[i], array[j]] = [array[j], array[i]];
+        }
+        return array;
+    }
+
     initializeDefaultExercises() {
         this.exercises = {
             "Sentadilla": {
@@ -145,14 +154,25 @@ class TrainingGenerator {
             <p><strong>Tiempo por sesión:</strong> ${timePerSession} minutos</p>
         `;
 
+        // Mezclar y preparar ejercicios
+        let exercisesPool = this.shuffleArray([...filteredExercises]);
+        const exercisesPerDay = Math.max(3, Math.ceil(exercisesPool.length / days));
+        let exerciseIndex = 0;
+
         for (let day = 1; day <= days; day++) {
             plan += `<div class="day">
                 <h4>Día ${day}</h4>
                 <div class="exercises-list">`;
 
-            // Seleccionar ejercicios para este día
-            const dayExercises = filteredExercises.slice(0, Math.ceil(filteredExercises.length / days));
-            filteredExercises = filteredExercises.slice(Math.ceil(filteredExercises.length / days));
+            const dayExercises = [];
+            for (let i = 0; i < exercisesPerDay; i++) {
+                if (exerciseIndex >= exercisesPool.length) {
+                    exerciseIndex = 0;
+                    exercisesPool = this.shuffleArray([...exercisesPool]);
+                }
+                dayExercises.push(exercisesPool[exerciseIndex]);
+                exerciseIndex++;
+            }
 
             dayExercises.forEach(exercise => {
                 const executionSteps = exercise.ejecucion ? exercise.ejecucion.map(step => `<li>${step}</li>`).join('') : '';


### PR DESCRIPTION
## Summary
- allow choosing 1 to 7 training days
- randomize exercises so each day has several different exercises

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6840ab6ca424832ca2ee7f4b428a2a2b